### PR TITLE
Bewertete Version

### DIFF
--- a/ModSim WS1718 Uebung 03.ipynb
+++ b/ModSim WS1718 Uebung 03.ipynb
@@ -161,6 +161,7 @@
    "metadata": {},
    "source": [
     "Der Wahrheitsweit der Aussage ist falsch. Nach dem Berechnungsprinzip werden die Gleitkommazahlen, vor allem die Nachkommastellen, durch Bruchteile berechnet und dargestellt. Somit lassen sich die Nachkommastellen nicht 100%ig richtig darstellen. Demgegenüber ist 0.3 ein präziser Wert, weil wir ihn als solchen definiert haben."
+    #sehen Commit nachricht
    ]
   }
  ],


### PR DESCRIPTION
Af3.  Nachkommastellen wird nicht durch Bruchteile berechnet, sondern durch Binär dargestellt und berechnet. (-5)